### PR TITLE
검색 결과 폰번호 클릭시 CouponsDisplay의 화면 변경 기능 && .html 언어 ko로 변경

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/src/components/Admin/Info/Coupons/CouponsDisplay.jsx
+++ b/src/components/Admin/Info/Coupons/CouponsDisplay.jsx
@@ -1,16 +1,8 @@
 import React, { Component } from 'react';
 
 export default class CouponsDisplay extends Component {
-  constructor(props) {
-    super(props);
-    const { count, REQUIRED } = props.counts;
-    this.state = {
-      count,
-      REQUIRED
-    };
-  }
   render() {
-    const { count, REQUIRED } = this.state;
+    const { count, REQUIRED } = this.props.counts;
     const couponsArray = [];
     for (let i = 0; i < count; i++) {
       couponsArray.push(

--- a/src/components/Admin/Info/index.jsx
+++ b/src/components/Admin/Info/index.jsx
@@ -2,20 +2,12 @@ import React, { Component } from 'react';
 import Coupons from './Coupons';
 import AddCustomer from './AddCustomer';
 
-const fakeData = { id: 1, count: 4 }; // 일단은 한 고객의 적립정보를 서버에서 받아온 것
-
-const REQUIRED = 10; // 서버에서 받아온 개수임
-
 export default class Info extends Component {
   render() {
-    const { isClickedAddCustomer, isClickedCustomer } = this.props;
+    const { isClickedAddCustomer, isClickedCustomer, counts } = this.props;
     return (
       <div className="col-9">
-        {isClickedCustomer ? (
-          <Coupons counts={{ count: fakeData.count, REQUIRED }} />
-        ) : (
-          ''
-        )}
+        {isClickedCustomer ? <Coupons counts={counts} /> : ''}
         {isClickedAddCustomer ? <AddCustomer /> : ''}
       </div>
     );

--- a/src/components/Admin/Search/index.jsx
+++ b/src/components/Admin/Search/index.jsx
@@ -3,6 +3,8 @@ import Input from '../../common/Input';
 import SearchResult from './SearchResult';
 import { Map, List } from 'immutable';
 import './index.css';
+import utils from '../../../utils';
+
 export default class Search extends Component {
   constructor(props) {
     super(props);
@@ -11,7 +13,7 @@ export default class Search extends Component {
     };
     this.debouncedHandleOnChange = this.debounce(
       this.handleOnChange.bind(this),
-      500
+      0
     );
   }
 
@@ -25,14 +27,10 @@ export default class Search extends Component {
 
   handleOnChange = val => {
     if (val.length === 4) {
-      fetch('http://localhost:3001/stores/customers/find-last-number', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ phoneNumber: val })
-      })
-        .then(response => response.json())
+      utils
+        .fetchPostData('/stores/customers/find-last-number', {
+          phoneNumber: val
+        })
         .then(users => {
           let list = List([]);
           users.forEach(user => {

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Search from './Search';
 import Info from './Info';
+import utils from '../../utils';
 
 export default class Admin extends Component {
   constructor(props) {
@@ -8,7 +9,12 @@ export default class Admin extends Component {
     this.state = {
       // inital state
       isClickedAddCustomer: false,
-      isClickedCustomer: false
+      isClickedCustomer: false,
+      // 로그인 성공시 받아오는 정보
+      STORE_ID: 2, // 매장 ID. 적립된 쿠폰 수 조회 및 손님등록시 필요
+      REQUIRED: 10, // 필요 쿠폰 수
+      // 손님 클릭시 가져올 정보
+      couponsCount: 1 // 적립한 쿠폰 수
     };
   }
 
@@ -20,18 +26,31 @@ export default class Admin extends Component {
   };
 
   clickCustomer = id => {
-    console.log(`id가 ${id}인 사용자를 클릭했음.`);
-    // 이제 서버에 해당 id 사용자의 적립된 쿠폰 수를 가져와야 함.
-    // 가져와서 state에 저장할 필요는 없고 id 랑 count 를 Info 컴포넌트에게 전달만 해주면 됨.
-    this.setState({
-      isClickedAddCustomer: false,
-      isClickedCustomer: true
-    });
+    utils
+      .fetchPostData('/stores/coupons/get-coupons-count', {
+        customerID: id,
+        storeID: this.state.STORE_ID
+      })
+      .then(response => {
+        this.setState({
+          isClickedAddCustomer: false,
+          isClickedCustomer: true,
+          couponsCount: response.count
+        });
+      })
+      .catch(error => {
+        console.log(error);
+      });
   };
 
   render() {
     const { clickAddCustomer, clickCustomer } = this;
-    const { isClickedAddCustomer, isClickedCustomer } = this.state;
+    const {
+      isClickedAddCustomer,
+      isClickedCustomer,
+      couponsCount,
+      REQUIRED
+    } = this.state;
     return (
       <div className="container outerHeight">
         <div className="row outerHeight">
@@ -42,6 +61,7 @@ export default class Admin extends Component {
           <Info
             isClickedAddCustomer={isClickedAddCustomer}
             isClickedCustomer={isClickedCustomer}
+            counts={{ count: couponsCount, REQUIRED }}
           />
         </div>
       </div>


### PR DESCRIPTION
검색 결과로 찾은 폰번호 클릭
-> 그 손님의 id와 현 매장 id를 get-coupons-count API에 요청 날림
-> 적립된 쿠폰 개수가 응답으로 옴
-> CouponsDisplay까지 정보를 전달해 화면이 변경되도록 함

&& public/index.html 의 lang 설정을 en -> ko 로 변경해 크롬에서 페이지 번역하기 뜨지 않도록 함